### PR TITLE
Fix/structure

### DIFF
--- a/src/lambdas/add-item/add_item.py
+++ b/src/lambdas/add-item/add_item.py
@@ -3,42 +3,52 @@ import os
 import boto3
 import uuid
 
-dynamodb = boto3.resource('dynamodb')
-nome_tabela = os.environ.get('NOME_TABELA')
+dynamodb = boto3.resource("dynamodb")
+nome_tabela = os.environ.get("NOME_TABELA")
 tabela = dynamodb.Table(nome_tabela)
+
 
 def add_item_handler(event, context):
     try:
-        if not event.get('data') or not event.get('nome'):
+
+        user_id = event["requestContext"]["authorizer"]["jwt"]["claims"]["sub"]
+
+        if not event.get("data") or not event.get("nome"):
             return {
-                'statusCode': 400, 
-                'body': json.dumps({
-                    'mensagem': 'Erro ao adicionar item',
-                    'erro': 'Data e nome são obrigatórios'
-                })
+                "statusCode": 400,
+                "body": json.dumps(
+                    {
+                        "mensagem": "Erro ao adicionar item",
+                        "erro": "Data e nome são obrigatórios",
+                    }
+                ),
             }
+
         item_id = str(uuid.uuid4())
+
         tabela.put_item(
             Item={
-            'SK': 'ITEM#' + item_id,
-            'PK': 'LIST#' + event.get('data'),
-            'nome': event.get('nome'),
-            'status': 'todo'            
-        })
+                "PK": f"USER#{user_id}",
+                "SK": "ITEM#" + item_id,
+                "data": event.get("data"),
+                "nome": event.get("nome"),
+                "status": "todo",
+            }
+        )
+
         return {
-            'statusCode': 201,
-            'body': json.dumps({
-                'mensagem': 'Item adicionado com sucesso',
-                'nome': event.get('nome'),
-                'data': event.get('data'),
-                'status': event.get('status')                                
-            })
+            "statusCode": 201,
+            "body": json.dumps(
+                {
+                    "mensagem": "Item adicionado com sucesso",
+                    "nome": event.get("nome"),
+                    "data": event.get("data"),
+                    "status": event.get("status"),
+                }
+            ),
         }
     except Exception as e:
         return {
-            'statusCode': 500,
-            'body': json.dumps({
-                'mensagem': 'Erro ao adicionar item',
-                'erro': str(e)
-            })
+            "statusCode": 500,
+            "body": json.dumps({"mensagem": "Erro ao adicionar item", "erro": str(e)}),
         }

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -6,6 +6,11 @@ from unittest.mock import patch, MagicMock
 os.environ["NOME_TABELA"] = "test_table"
 
 
+@pytest.fixture
+def user_event(sub="test-user-id"):
+    return {"requestContext": {"authorizer": {"jwt": {"claims": {"sub": sub}}}}}
+
+
 @pytest.fixture(autouse=True)
 def mock_dynamodb_table():
     with patch("lambdas.get_items.get_items.table") as mock_table:
@@ -14,11 +19,13 @@ def mock_dynamodb_table():
 
 @pytest.fixture
 def sample_item():
+    uid = "test-user-id"
     return [
         {
-            "pk": "LIST#2025-12-12",
-            "sk": f"ITEM#{uuid.uuid4()}",
+            "PK": f"USER#{uid}",
+            "SK": f"ITEM#{uuid.uuid4()}",
             "nome": "buy milk",
+            "data": "2025-12-12",
             "status": "todo",
         }
     ]

--- a/src/tests/test_get_items.py
+++ b/src/tests/test_get_items.py
@@ -2,32 +2,32 @@ import json
 from lambdas.get_items.get_items import get_items_handler
 
 
-def test_get_items_success(mock_dynamodb_table, sample_item):
+def test_get_items_success(mock_dynamodb_table, sample_item, user_event):
 
-    expected_items = [sample_item]
-    mock_dynamodb_table.scan.return_value = {"Items": expected_items}
+    expected_items = sample_item
+    mock_dynamodb_table.query.return_value = {"Items": expected_items}
 
-    response = get_items_handler({}, {})
+    response = get_items_handler(user_event, {})
 
     assert response["statusCode"] == 200
     assert json.loads(response["body"]) == expected_items
 
 
-def test_get_items_empty_table(mock_dynamodb_table):
+def test_get_items_empty_table(mock_dynamodb_table, user_event):
 
-    mock_dynamodb_table.scan.return_value = {"Items": []}
+    mock_dynamodb_table.query.return_value = {"Items": []}
 
-    response = get_items_handler({}, {})
+    response = get_items_handler(user_event, {})
 
     assert response["statusCode"] == 200
     assert json.loads(response["body"]) == []
 
 
-def test_get_items_failure(mock_dynamodb_table):
+def test_get_items_failure(mock_dynamodb_table, user_event):
 
-    mock_dynamodb_table.scan.side_effect = Exception("simulated error")
+    mock_dynamodb_table.query.side_effect = Exception("simulated error")
 
-    response = get_items_handler({}, {})
+    response = get_items_handler(user_event, {})
 
     assert response["statusCode"] == 500
     assert "simulated error" in json.loads(response["body"])["error"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket = "tais-items-list"
+    bucket = "tais-shopping-list"
     key    = "state/terraform.tfstate"
     region = "us-east-1"
   }
@@ -218,7 +218,10 @@ resource "aws_iam_policy" "lambda_dynamodb_policy" {
           "dynamodb:Scan"
         ],
         Effect   = "Allow",
-        Resource = aws_dynamodb_table.item_table.arn
+        Resource = [
+          aws_dynamodb_table.item_table.arn,
+          "${aws_dynamodb_table.item_table.arn}/index/SK-index"
+        ]
       },
       {
         Action = [
@@ -262,9 +265,9 @@ module "cognito" {
 module "api" {
   source            = "./modules/api_gateway"
   lambda_arn        = aws_lambda_function.hello.arn
+  get_lambda_arn    = aws_lambda_function.get_items.arn
   lambda_arn_get    = aws_lambda_function.get_items.arn
   user_pool_id      = module.cognito.user_pool_id
   region            = var.region
   cognito_client_id = module.cognito.user_pool_client_id
-  account_id        = var.account_id
 }

--- a/terraform/modules/api_gateway/main.tf
+++ b/terraform/modules/api_gateway/main.tf
@@ -17,7 +17,7 @@ resource "aws_apigatewayv2_authorizer" "cognito" {
 resource "aws_apigatewayv2_integration" "list_integration" {
   api_id                 = aws_apigatewayv2_api.http_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/${var.lambda_arn}/invocations"
+  integration_uri        = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/${var.get_lambda_arn}/invocations"
   integration_method     = "POST"
   payload_format_version = "2.0"
 }

--- a/terraform/modules/api_gateway/variables.tf
+++ b/terraform/modules/api_gateway/variables.tf
@@ -23,8 +23,8 @@ variable "cognito_client_id" {
   type        = string
 }
 
-variable "account_id" {
-  description = "AWS Account ID"
+variable "get_lambda_arn" {
+  description = "GET lambda arn"
   type        = string
 }
 


### PR DESCRIPTION
- changed get_items to use DynamoDB `query` instead of `scan`
- modified add_item to use the authenticated user's ID as the partition key (PK), ensuring only items created by that user are returned
- updated tests to reflect changes in query logic and key structure
- formatted code using Black