### PR TITLE
Adiciona o caminho para editar item e testes unitários

### DIFF
--- a/src/lambdas/edit_item/edit_item.py
+++ b/src/lambdas/edit_item/edit_item.py
@@ -4,7 +4,7 @@ import boto3
 
 dynamodb = boto3.resource('dynamodb')
 nome_tabela = os.environ.get('NOME_TABELA')
-tabela = dynamodb.Table(nome_tabela)
+table = dynamodb.Table(nome_tabela)
 
 def edit_item_handler(event, context):
     try:
@@ -15,7 +15,7 @@ def edit_item_handler(event, context):
                 'body': json.dumps({'mensagem': 'O status deve ser "todo" ou "done"'})
             }
         
-        response = tabela.get_item(
+        response = table.get_item(
             Key={
                 'SK': event['sk'],
                 'PK': event['pk']
@@ -27,7 +27,7 @@ def edit_item_handler(event, context):
                 'body': json.dumps({'mensagem': 'Item não encontrado'})
             }
         
-        tabela.update_item(
+        table.update_item(
             Key={
                 'SK': event['sk'],
                 'PK': event['pk']

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,7 +1,15 @@
+import sys
 import pytest
 import os
 import uuid
 from unittest.mock import patch, MagicMock
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+src_path = os.path.abspath(os.path.join(current_dir, "..", "..")) 
+
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
 
 os.environ["NOME_TABELA"] = "test_table"
 
@@ -13,7 +21,7 @@ def user_event(sub="test-user-id"):
 
 @pytest.fixture(autouse=True)
 def mock_dynamodb_table():
-    with patch("lambdas.get_items.get_items.table") as mock_table:
+    with patch("src.lambdas.get_items.get_items.table") as mock_table:
         yield mock_table
 
 

--- a/src/tests/test_edit_item.py
+++ b/src/tests/test_edit_item.py
@@ -1,0 +1,150 @@
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.lambdas.edit_item.edit_item import edit_item_handler
+
+@pytest.fixture(autouse=True)
+def mock_dynamodb_table():
+    with patch("src.lambdas.edit_item.edit_item.table") as mock_table:
+        yield mock_table
+
+def test_edit_item_success(mock_dynamodb_table):
+    """
+    Testa a atualização bem-sucedida de um item existente.
+    """
+    mock_dynamodb_table.get_item.return_value = {
+        'Item': {
+            'PK': 'USER#test-user',
+            'SK': 'ITEM#123',
+            'nome': 'item antigo',
+            'status': 'todo'
+        }
+    }
+    mock_dynamodb_table.update_item.return_value = {}
+
+    event = {
+        'pk': 'USER#test-user',
+        'sk': 'ITEM#123',
+        'nome': 'novo nome do item',
+        'status': 'done'
+    }
+    context = {}
+
+    response = edit_item_handler(event, context)
+
+    assert response == {
+        'mensagem': 'Item atualizado com sucesso',
+        'status': 'done',
+        'nome': 'novo nome do item'
+    }
+    mock_dynamodb_table.get_item.assert_called_once_with(
+        Key={
+            'SK': 'ITEM#123',
+            'PK': 'USER#test-user'
+        }
+    )
+    mock_dynamodb_table.update_item.assert_called_once_with(
+        Key={
+            'SK': 'ITEM#123',
+            'PK': 'USER#test-user'
+        },
+        UpdateExpression='SET nome = :nome, #st = :status',
+        ExpressionAttributeValues={
+            ':nome': 'novo nome do item',
+            ':status': 'done'
+        },
+        ExpressionAttributeNames={
+            '#st': 'status'
+        }
+    )
+
+def test_edit_item_invalid_status(mock_dynamodb_table):
+    """
+    Testa a validação de status inválido.
+    """
+    event = {
+        'pk': 'USER#test-user',
+        'sk': 'ITEM#123',
+        'nome': 'item qualquer',
+        'status': 'invalid_status'
+    }
+    context = {}
+
+    response = edit_item_handler(event, context)
+
+    assert response == {
+        'statusCode': 400,
+        'body': json.dumps({'mensagem': 'O status deve ser "todo" ou "done"'})
+    }
+    mock_dynamodb_table.get_item.assert_not_called()
+    mock_dynamodb_table.update_item.assert_not_called()
+
+def test_edit_item_not_found(mock_dynamodb_table):
+    """
+    Testa o cenário em que o item não é encontrado.
+    """
+    mock_dynamodb_table.get_item.return_value = {}
+    mock_dynamodb_table.update_item.return_value = {}
+
+    event = {
+        'pk': 'USER#test-user',
+        'sk': 'ITEM#123',
+        'nome': 'novo nome',
+        'status': 'todo'
+    }
+    context = {}
+
+    response = edit_item_handler(event, context)
+
+    assert response == {
+        'statusCode': 404,
+        'body': json.dumps({'mensagem': 'Item não encontrado'})
+    }
+    mock_dynamodb_table.get_item.assert_called_once_with(
+        Key={
+            'SK': 'ITEM#123',
+            'PK': 'USER#test-user'
+        }
+    )
+    mock_dynamodb_table.update_item.assert_not_called()
+
+def test_edit_item_general_exception(mock_dynamodb_table):
+    """
+    Testa o tratamento de exceções inesperadas.
+    """
+    mock_dynamodb_table.get_item.side_effect = Exception("Erro de teste")
+
+    event = {
+        'pk': 'USER#test-user',
+        'sk': 'ITEM#123',
+        'nome': 'novo nome',
+        'status': 'done'
+    }
+    context = {}
+
+    response = edit_item_handler(event, context)
+
+    assert response['statusCode'] == 500
+    assert json.loads(response['body'])['mensagem'] == 'Erro inesperado'
+    assert 'erro' in json.loads(response['body'])
+    mock_dynamodb_table.get_item.assert_called_once()
+    mock_dynamodb_table.update_item.assert_not_called()
+
+def test_edit_item_missing_keys(mock_dynamodb_table):
+    """
+    Testa o cenário em que as chaves PK ou SK estão faltando no evento.
+    """
+    event = {
+        'nome': 'algum nome',
+        'status': 'todo'
+    }
+    context = {}
+
+    response = edit_item_handler(event, context)
+
+    assert response['statusCode'] == 500
+    assert json.loads(response['body'])['mensagem'] == 'Erro inesperado'
+    assert 'erro' in json.loads(response['body'])
+    mock_dynamodb_table.get_item.assert_not_called()
+    mock_dynamodb_table.update_item.assert_not_called()

--- a/src/tests/test_get_items.py
+++ b/src/tests/test_get_items.py
@@ -1,5 +1,5 @@
 import json
-from lambdas.get_items.get_items import get_items_handler
+from src.lambdas.get_items.get_items import get_items_handler
 
 
 def test_get_items_success(mock_dynamodb_table, sample_item, user_event):

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,8 +58,8 @@ data "archive_file" "add_zip" {
 
 data "archive_file" "edit_zip" {
   type        = "zip"
-  source_dir  = "../src/lambdas/edit-item/"
-  output_path = "../src/lambdas/edit-item/edit_item.zip"
+  source_dir  = "../src/lambdas/edit_item/"
+  output_path = "../src/lambdas/edit_item/edit_item.zip"
 }
 
 data "archive_file" "remove_zip" {
@@ -267,6 +267,7 @@ module "api" {
   lambda_arn        = aws_lambda_function.hello.arn
   get_lambda_arn    = aws_lambda_function.get_items.arn
   lambda_arn_get    = aws_lambda_function.get_items.arn
+  edit_lambda_arn   = aws_lambda_function.edit_item.arn
   user_pool_id      = module.cognito.user_pool_id
   region            = var.region
   cognito_client_id = module.cognito.user_pool_client_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,12 @@ resource "aws_dynamodb_table" "item_table" {
     name = "SK"
     type = "S"
   }
+
+  global_secondary_index {
+    name            = "SK-index"
+    hash_key        = "SK"
+    projection_type = "ALL"
+  }
 }
 
 data "archive_file" "hello_zip" {
@@ -217,7 +223,7 @@ resource "aws_iam_policy" "lambda_dynamodb_policy" {
           "dynamodb:Query",
           "dynamodb:Scan"
         ],
-        Effect   = "Allow",
+        Effect = "Allow",
         Resource = [
           aws_dynamodb_table.item_table.arn,
           "${aws_dynamodb_table.item_table.arn}/index/SK-index"

--- a/terraform/modules/api_gateway/main.tf
+++ b/terraform/modules/api_gateway/main.tf
@@ -30,6 +30,15 @@ resource "aws_apigatewayv2_integration" "lambda_integration" {
   payload_format_version = "2.0"
 }
 
+# Integração para a lambda de editar itens
+resource "aws_apigatewayv2_integration" "edit_integration" {
+  api_id                 = aws_apigatewayv2_api.http_api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/${var.edit_lambda_arn}/invocations"
+  integration_method     = "POST" # Lambdas proxy geralmente recebem POST
+  payload_format_version = "2.0"
+}
+
 resource "aws_lambda_permission" "allow_apigw_invoke" {
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
@@ -42,6 +51,15 @@ resource "aws_lambda_permission" "allow_list_invoke" {
   statement_id  = "AllowExecutionFromAPIGatewayList"
   action        = "lambda:InvokeFunction"
   function_name = var.lambda_arn_get
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*"
+}
+
+# Permissão para a lambda de editar itens
+resource "aws_lambda_permission" "allow_edit_invoke" {
+  statement_id  = "AllowExecutionFromAPIGatewayEdit"
+  action        = "lambda:InvokeFunction"
+  function_name = var.edit_lambda_arn
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*"
 }
@@ -65,6 +83,17 @@ resource "aws_apigatewayv2_route" "list" {
   authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
 
   target = "integrations/${aws_apigatewayv2_integration.list_integration.id}"
+}
+
+# Rota para editar itens
+resource "aws_apigatewayv2_route" "edit_item" {
+  api_id             = aws_apigatewayv2_api.http_api.id
+  route_key          = "PUT /list-items/{item_id}"
+
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
+
+  target = "integrations/${aws_apigatewayv2_integration.edit_integration.id}"
 }
 
 resource "aws_apigatewayv2_stage" "default" {

--- a/terraform/modules/api_gateway/variables.tf
+++ b/terraform/modules/api_gateway/variables.tf
@@ -28,3 +28,7 @@ variable "get_lambda_arn" {
   type        = string
 }
 
+variable "edit_lambda_arn" {
+  description = "ARN da função Lambda de editar itens"
+  type        = string
+}


### PR DESCRIPTION
Refatora a lambda de editar itens e a tabela do DynamoDB para criar um GSI com SK como chave primária (SK-index), possibilitando a seleção de um item através do item_id

Adiciona testes unitário à lambda de editar itens

Refatora o arquivo conftest para ser utilizado para os testes do projeto

Configura a integração, autorização e rota do método POST da lambda com a API Gateway, no caminho list-items
